### PR TITLE
Fix Share intent handling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
 		<activity
 			android:name=".activity.CameraActivity"
 			android:label="@string/scan_code">
-			<intent-filter>
+			<intent-filter android:label="@string/compose_barcode">
 				<action android:name="android.intent.action.SEND"/>
 				<category android:name="android.intent.category.DEFAULT"/>
 				<data android:mimeType="text/plain"/>

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
@@ -113,6 +113,7 @@ class CameraActivity : AppCompatActivity() {
 		returnResult = "com.google.zxing.client.android.SCAN".equals(
 			intent.action
 		)
+		handleSendText(intent)
 		if (hasCameraPermission()) {
 			cameraView.openAsync(
 				CameraView.findCameraId(
@@ -183,7 +184,8 @@ class CameraActivity : AppCompatActivity() {
 		// consume this intent
 		intent.setAction(null)
 
-		startActivity(MainActivity.getEncodeIntent(this, text))
+		startActivity(MainActivity.getEncodeIntent(this, text, true))
+		finish()
 	}
 
 	private fun hasCameraPermission(): Boolean {

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/MainActivity.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/MainActivity.kt
@@ -59,9 +59,14 @@ class MainActivity : AppCompatActivity() {
 		private const val DECODE = "decode"
 		private const val DECODE_FORMAT = "decode_format"
 
-		fun getEncodeIntent(context: Context, text: String? = ""): Intent {
+		fun getEncodeIntent(context: Context, text: String? = "", external: Boolean = false): Intent {
 			val intent = Intent(context, MainActivity::class.java)
 			intent.putExtra(ENCODE, text)
+			if (external) {
+				intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NO_HISTORY or
+						android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK or
+						android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+			}
 			return intent
 		}
 


### PR DESCRIPTION
Always when I wanted to encode some text via the Android share menu, only the `CameraActivity` got started and the text to encode got lost.

That happened because `onNewIntent` is [only called when some prerequisites are met](https://developer.android.com/reference/android/app/Activity#onNewIntent(android.content.Intent)).

This PR adds checking for Intents in `onCreate` and also ensures it will be properly handled not reusing some old text values (see new flags inside `getEncodeIntent`). Also, the `finish` at the end makes the activity return to the sending app using the back button instead of opening the `CameraActivity`.