### PR TITLE
Handle no supported scene modes

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
@@ -220,15 +220,15 @@ class CameraActivity : AppCompatActivity() {
 				} else {
 					zoomBar.visibility = View.GONE
 				}
-                val sceneModes = parameters.getSupportedSceneModes()
-                sceneModes?.let {
-                    for (mode in sceneModes) {
-                        if (mode.equals(Camera.Parameters.SCENE_MODE_BARCODE)) {
-                            parameters.sceneMode = mode
-                            break
-                        }
-                    }
-                }
+				val sceneModes = parameters.getSupportedSceneModes()
+				sceneModes?.let {
+					for (mode in sceneModes) {
+						if (mode.equals(Camera.Parameters.SCENE_MODE_BARCODE)) {
+							parameters.sceneMode = mode
+							break
+						}
+					}
+				}
 				CameraView.setAutoFocus(parameters)
 			}
 

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
@@ -220,12 +220,15 @@ class CameraActivity : AppCompatActivity() {
 				} else {
 					zoomBar.visibility = View.GONE
 				}
-				for (mode in parameters.getSupportedSceneModes()) {
-					if (mode.equals(Camera.Parameters.SCENE_MODE_BARCODE)) {
-						parameters.sceneMode = mode
-						break
-					}
-				}
+                val sceneModes = parameters.getSupportedSceneModes()
+                sceneModes?.let {
+                    for (mode in sceneModes) {
+                        if (mode.equals(Camera.Parameters.SCENE_MODE_BARCODE)) {
+                            parameters.sceneMode = mode
+                            break
+                        }
+                    }
+                }
 				CameraView.setAutoFocus(parameters)
 			}
 


### PR DESCRIPTION
Only search for `SCENE_MODE_BARCODE` if there are any supported scene modes. This extra check prevents triggering `onCameraError()` when there are no supported scene modes, which would result in an unusable application for some devices.