### PR TITLE
Fix crash caused by missing `\R` support for Regex

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/actions/vtype/VType.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/actions/vtype/VType.kt
@@ -1,8 +1,9 @@
 package de.markusfisch.android.binaryeye.actions.vtype
 
 object VTypeParser {
+	private const val BACKSLASH_R_LEGACY = "(?:\u000D\u000A|[\u000A\u000B\u000C\u000D\u0085\u2028\u2029])"
 	private val vTypeRegex =
-		"""^BEGIN:(VCARD|VEVENT)(?:\R.+?:[\s\S]+?)+?\REND:\1\R?$""".toRegex(RegexOption.IGNORE_CASE)
+		"""^BEGIN:(VCARD|VEVENT)(?:$BACKSLASH_R_LEGACY.+?:[\s\S]+?)+?\REND:\1$BACKSLASH_R_LEGACY?$""".toRegex(RegexOption.IGNORE_CASE)
 	private val propertyRegex = """^(.+?):([\s\S]*?)$""".toRegex(RegexOption.MULTILINE)
 
 	fun parseVType(data: String): String? =

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/actions/vtype/VType.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/actions/vtype/VType.kt
@@ -3,7 +3,7 @@ package de.markusfisch.android.binaryeye.actions.vtype
 object VTypeParser {
 	private const val BACKSLASH_R_LEGACY = "(?:\u000D\u000A|[\u000A\u000B\u000C\u000D\u0085\u2028\u2029])"
 	private val vTypeRegex =
-		"""^BEGIN:(VCARD|VEVENT)(?:$BACKSLASH_R_LEGACY.+?:[\s\S]+?)+?\REND:\1$BACKSLASH_R_LEGACY?$""".toRegex(RegexOption.IGNORE_CASE)
+		"""^BEGIN:(VCARD|VEVENT)(?:$BACKSLASH_R_LEGACY.+?:[\s\S]+?)+?${BACKSLASH_R_LEGACY}END:\1$BACKSLASH_R_LEGACY?$""".toRegex(RegexOption.IGNORE_CASE)
 	private val propertyRegex = """^(.+?):([\s\S]*?)$""".toRegex(RegexOption.MULTILINE)
 
 	fun parseVType(data: String): String? =


### PR DESCRIPTION
* Replaced `\R` usage in VType actions with official equivalent

Fixes #61 