### PR TITLE
Add content data section

### DIFF
--- a/app/src/main/res/layout/fragment_decode.xml
+++ b/app/src/main/res/layout/fragment_decode.xml
@@ -38,10 +38,19 @@
 				android:layout_marginBottom="16dp"
 				android:gravity="end|top"/>
 			<TableLayout
-				android:id="@+id/meta"
+				android:id="@+id/data"
 				android:layout_width="match_parent"
 				android:layout_height="wrap_content"
 				android:layout_below="@+id/format"
+				android:layout_marginEnd="16dp"
+				android:layout_marginStart="16dp"
+				android:layout_marginLeft="16dp"
+				android:layout_marginRight="16dp"/>
+			<TableLayout
+				android:id="@+id/meta"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_below="@+id/data"
 				android:layout_marginEnd="16dp"
 				android:layout_marginStart="16dp"
 				android:layout_marginLeft="16dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -147,4 +147,14 @@
 	<string name="shortcut_encode">Create a barcode</string>
 	<string name="shortcut_preferences">Settings</string>
 	<string name="background_request_failed">Background request failed</string>
+	<string name="entry_type">Type</string>
+	<string name="wifi_network">Wi-Fi network</string>
+	<string name="wifi_ssid">Name</string>
+	<string name="wifi_type">Authentication type</string>
+	<string name="wifi_password">Password</string>
+	<string name="wifi_hidden">Hidden network</string>
+	<string name="wifi_eap">EAP method</string>
+	<string name="wifi_anonymous_identity">Anonymous identity</string>
+	<string name="wifi_identity">Identity</string>
+	<string name="wifi_phase2">Phase 2 method</string>
 </resources>


### PR DESCRIPTION
Initially with only Wi-Fi info support, but could be extended in the future

This adds info about the scanned data to the screen. Currently, only Wi-Fi info is displayed, but this code can easily be extended to contain other types:

![image](https://user-images.githubusercontent.com/1885159/135765198-ba8f0f5b-fe27-450a-86e6-d1bcaadb9176.png)

Do note that I have changed the (meta)data display code to use a LinkedHashMap instead of a SortedMap because I wanted to keep my custom sorting order (I want "Type" to always be on top for these entries for readability's sake). If it is a problem that the metadata is no longer sorted alphabetically I can fix that, please tell me.

Hope this is useful :)