### PR TITLE
Optimize the 'save as text' function to make its results more recognizable when printing on the console

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/zxing/Zxing.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/zxing/Zxing.kt
@@ -171,12 +171,22 @@ fun encodeAsText(
 	val w = bitMatrix.width
 	val h = bitMatrix.height
 	val sb = StringBuilder()
-	for (y in 0 until h) {
-		for (x in 0 until w) {
-			sb.append(if (bitMatrix.get(x, y)) "█" else " ")
-		}
-		sb.append("\n")
-	}
+    for (y in 0 until h step 2) {
+        for (x in 0 until w) {
+            val tp = bitMatrix.get(y, x)
+            var bt = y + 1 >= h || bitMatrix.get(y + 1, x);
+            if (tp && bt) {
+                sb.append(' ')//'\u0020'
+            } else if (tp) {
+                sb.append('▄')//'\u2584'
+            } else if (bt) {
+                sb.append('▀')//'\u2580'
+            } else {
+                sb.append('█')//'\u2588'
+            }
+        }
+        sb.append('\n')
+    }
 	return sb.toString()
 }
 


### PR DESCRIPTION
Optimize the 'save as text' function to make its results more recognizable when printing on the console