### PR TITLE
Add dependency to multidex

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,4 +99,5 @@ dependencies {
 	implementation 'com.google.zxing:core:3.5.0'
 	implementation 'com.github.markusfisch:CameraView:1.9.1'
 	implementation 'com.github.markusfisch:ScalingImageView:1.4.0'
+	implementation 'com.android.support:multidex:1.0.3'
 }


### PR DESCRIPTION
I just tried to build BinaryEye with a freshly installed Android Studio. And it failed until I added `multidex` as a dependency, since it said it doesn't know multidex. Maybe I missed something obvious, since I haven't used multidex beforehand. But I thought it's worth mentioning.

Thanks for the great app!