### PR TITLE
Fixed PDF-417 UTF-8 text encoding

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
@@ -24,6 +24,7 @@ import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
 import android.widget.SeekBar
+import com.google.zxing.BarcodeFormat
 import com.google.zxing.Result
 import com.google.zxing.ResultMetadataType
 import de.markusfisch.android.binaryeye.R
@@ -46,6 +47,7 @@ import de.markusfisch.android.binaryeye.widget.DetectorView
 import de.markusfisch.android.binaryeye.widget.toast
 import de.markusfisch.android.binaryeye.zxing.Zxing
 import de.markusfisch.android.cameraview.widget.CameraView
+import java.nio.charset.Charset
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -459,7 +461,18 @@ class CameraActivity : AppCompatActivity() {
 							frameOrientation
 						)?.let { result ->
 							if (result.text != ignoreNext) {
-								postResult(result)
+								if (result.barcodeFormat == BarcodeFormat.PDF_417 && result.text != null) {
+									val iso88591Text = result.text.toByteArray(Charset.forName("ISO-8859-1"))
+									val utf8Text = String(iso88591Text, Charset.forName("UTF-8"))
+									postResult(Result(utf8Text,
+										result.rawBytes,
+										result.numBits,
+										result.resultPoints,
+										result.barcodeFormat,
+										result.timestamp))
+								} else {
+									postResult(result)
+								}
 								decoding = false
 							}
 						}


### PR DESCRIPTION
This fixes reading PDF-417 barcodes containing international UTF-8 characters.
QR codes are not affected and work fine with UTF-8.

I'm not sure whether this should be fixed upstream in zxing or here.
Have found a ticket upstream that **might** be related: https://github.com/zxing/zxing/issues/555

Reproduction steps:
1. Use some PDF-417 generator and create a code containing some non US (iso9959-1) letters e.g.
Open page here: https://www.free-barcode-generator.net/pdf417/
Paste this text `Tešting sòmè čharaćters`
And select `UTF-8` for `Output charater code page for characters with codes greater than 127 (characters outside selected code page will be ignored)` 

2. Scan the code with Binary Eye

3. Scanned string is wrong it says: `TeÅ¡ting sÃ²mÃ¨ ÄharaÄters`

4. With this patch scanned string is as expected it says `Tešting sòmè čharaćters`