### PR TITLE
Error beeping now follows settings

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/view/ScanFeedback.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/view/ScanFeedback.kt
@@ -22,7 +22,7 @@ fun Context.errorFeedback() {
 	if (prefs.vibrate) {
 		getVibrator().error()
 	}
-	if (!isSilent()) {
+	if (prefs.beep && !isSilent()) {
 		beepError()
 	}
 }


### PR DESCRIPTION
I noticed that the only way to stop the error beep from occurring was by silencing the device itself, which is odd given that the similarly worded vibration setting effects both error and confirmation.