### PR TITLE
GH-389 Fix missing Copy button for binary QRs

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/fragment/DecodeFragment.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/fragment/DecodeFragment.kt
@@ -300,7 +300,6 @@ class DecodeFragment : Fragment() {
 	override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
 		inflater.inflate(R.menu.fragment_decode, menu)
 		if (isBinary) {
-			menu.findItem(R.id.copy_to_clipboard).isVisible = false
 			menu.findItem(R.id.create).isVisible = false
 		}
 		if (id > 0L) {


### PR DESCRIPTION
It is now possible to copy the raw decoded content as a hex string with the "Copy" menu button.

QR codes for test:
<img width=600 src="https://github.com/markusfisch/BinaryEye/assets/5675681/55354a61-5dc0-47a7-9aa9-05e2000dcaa7" />

Result:
<img width=300 src="https://github.com/markusfisch/BinaryEye/assets/5675681/c838ed5c-8dc3-45d1-806d-b45a87fb0164" />
