### PR TITLE
Fix quick setting tile failed to launch on Android 14

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/service/ScanTileService.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/service/ScanTileService.kt
@@ -1,5 +1,6 @@
 package de.markusfisch.android.binaryeye.service
 
+import android.app.PendingIntent
 import android.content.Intent
 import android.os.Build
 import android.service.quicksettings.TileService
@@ -12,6 +13,17 @@ class ScanTileService : TileService() {
 		super.onClick()
 		val intent = Intent(applicationContext, CameraActivity::class.java)
 		intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-		startActivityAndCollapse(intent)
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+			@Suppress("DEPRECATION")
+			startActivityAndCollapse(intent)
+		} else {
+			val pendingIntent = PendingIntent.getActivity(
+				this,
+				0,
+				intent,
+				PendingIntent.FLAG_IMMUTABLE
+			)
+			startActivityAndCollapse(pendingIntent)
+		}
 	}
 }


### PR DESCRIPTION
[SDK 34 deprecates `startActivityAndCollapse(Intent)`](https://developer.android.com/reference/android/service/quicksettings/TileService.html#startActivityAndCollapse(android.content.Intent)), making it throws an UnsupportedOperationException on Android 14 devices instead of launching the app.

Added new function call for API 34, tested with Android 14 and Android 9 devices.