### PR TITLE
Simplification and clean up of Gradle files

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,14 +2,14 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-	namespace 'de.markusfisch.android.binaryeye'
+	namespace "de.markusfisch.android.binaryeye"
 	compileSdk sdk_version
+
 	defaultConfig {
 		minSdk 9
 		targetSdk sdk_version
-
-		versionCode 123
-		versionName '1.61.2'
+		versionCode 127
+		versionName '1.62.3'
 	}
 
 	signingConfigs {
@@ -52,18 +52,30 @@ android {
 			enableSplit = false
 		}
 	}
+
+	compileOptions {
+		// Required for Gradle 8.
+		sourceCompatibility = 17
+		targetCompatibility = 17
+	}
 }
 
 dependencies {
+	// Kotlin
 	implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 	implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
+
+	// Support
 	implementation "com.android.support:appcompat-v7:$support_version"
 	implementation "com.android.support:design:$support_version"
 	implementation "com.android.support:preference-v7:$support_version"
 	implementation "com.android.support:preference-v14:$support_version"
+
+	// External
 	implementation 'com.github.markusfisch:CameraView:1.9.2'
 	implementation 'com.github.markusfisch:ScalingImageView:1.4.1'
-	implementation 'com.github.markusfisch:zxing-cpp:v2.1.0.2'
+	implementation 'com.github.markusfisch:zxing-cpp:v2.2.0.1'
 
+	// Testing
 	testImplementation 'junit:junit:4.13.2'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'kotlin-android'
 
 android {
 	namespace 'de.markusfisch.android.binaryeye'
-	compileSdkVersion sdk_version
+	compileSdk sdk_version
 	defaultConfig {
-		minSdkVersion 9
-		targetSdkVersion sdk_version
+		minSdk 9
+		targetSdk sdk_version
 
-		versionCode 127
-		versionName '1.62.3'
+		versionCode 123
+		versionName '1.61.2'
 	}
 
 	signingConfigs {
@@ -52,18 +52,9 @@ android {
 			enableSplit = false
 		}
 	}
-
-
-	compileOptions {
-		// Required for Gradle 8.
-		sourceCompatibility = 17
-		targetCompatibility = 17
-	}
 }
 
 dependencies {
-	testImplementation 'junit:junit:4.13.2'
-
 	implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 	implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
 	implementation "com.android.support:appcompat-v7:$support_version"
@@ -72,5 +63,7 @@ dependencies {
 	implementation "com.android.support:preference-v14:$support_version"
 	implementation 'com.github.markusfisch:CameraView:1.9.2'
 	implementation 'com.github.markusfisch:ScalingImageView:1.4.1'
-	implementation 'com.github.markusfisch:zxing-cpp:v2.2.0.1'
+	implementation 'com.github.markusfisch:zxing-cpp:v2.1.0.2'
+
+	testImplementation 'junit:junit:4.13.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,14 @@ allprojects {
 	}
 
 	gradle.projectsEvaluated {
-		tasks.withType(JavaCompile) {
-			options.compilerArgs << "-Xlint:unchecked"
+		tasks.withType(JavaCompile).tap {
+			configureEach {
+				options.compilerArgs << "-Xlint:unchecked"
+			}
 		}
 	}
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
 	delete rootProject.buildDir
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,6 @@ buildscript {
 }
 
 allprojects {
-	repositories {
-		google()
-		mavenCentral()
-		maven { url 'https://jitpack.io' }
-	}
-
 	gradle.projectsEvaluated {
 		tasks.withType(JavaCompile).tap {
 			configureEach {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,5 +2,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
+networkTimeout=10000
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = "Binary Eye"
 include ':app'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,3 @@
-import org.gradle.api.initialization.resolve.RepositoriesMode
-
 pluginManagement {
     repositories {
         google()
@@ -7,7 +5,6 @@ pluginManagement {
         maven { url 'https://jitpack.io' }
     }
 }
-
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,21 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
+    }
+}
+
 rootProject.name = "Binary Eye"
 include ':app'


### PR DESCRIPTION
I tried to clean up our Gradle files a bit by:

- Implementing some linting suggestions
- Moving some things around for clarity
- Replacing deprecated methods with new ones
- Transferring all repo declarations to the settings file

P.S. Gradle sync works fine but please test for yourself if the app compiles. I can't test because of a
`java.lang.UnsatisfiedLinkError: dlopen failed: library "libzxing.so" not found` error.