### PR TITLE
Fixes issue of missing send due to invalid bluetooth socket connection

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/bluetooth/BluetoothSender.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/bluetooth/BluetoothSender.kt
@@ -21,10 +21,10 @@ fun Scan.sendBluetoothAsync(
 		val connected = if (isConnected) {
 			true
 		} else {
-			connect(host)
+			connect(host,true)
 		}
 		val sent = if (connected) {
-			send(content)
+			send(content,host,true)
 		} else {
 			false
 		}
@@ -62,7 +62,7 @@ private val uuid = UUID.fromString(
 
 private var isConnected = false
 
-private fun connect(deviceName: String): Boolean = try {
+private fun connect(deviceName: String, onceMore: Boolean): Boolean = try {
 	val device = findByName(deviceName) ?: throw RuntimeException(
 		"Bluetooth device not found"
 	)
@@ -72,11 +72,15 @@ private fun connect(deviceName: String): Boolean = try {
 	isConnected = true
 	true
 } catch (e: Exception) {
-	close()
+	if (onceMore)
+		connect(deviceName, false)
+	else
+		close()
+	//TODO do i need the extra catch here? hmmm. line 74-79
 	false
 }
 
-private fun send(message: String): Boolean = try {
+private fun send(message: String, host: String, onceMore: Boolean): Boolean = try {
 	writer?.apply {
 		write(message)
 		write("\n")
@@ -85,7 +89,11 @@ private fun send(message: String): Boolean = try {
 	true
 } catch (e: Exception) {
 	close()
-	false
+
+	if (connect(host, false))
+		send(message, host, false)
+	else
+		false
 }
 
 private fun close() {

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/bluetooth/BluetoothSender.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/bluetooth/BluetoothSender.kt
@@ -76,7 +76,6 @@ private fun connect(deviceName: String, onceMore: Boolean): Boolean = try {
 		connect(deviceName, false)
 	else
 		close()
-	//TODO do i need the extra catch here? hmmm. line 74-79
 	false
 }
 


### PR DESCRIPTION
There is no way to truly check if the bluetooth connection is still valid without failing to send, because [API level 14 is required for that function.](https://developer.android.com/reference/android/bluetooth/BluetoothSocket#isConnected())



Currently, given the following situation:
1. First connect to bluetooth socket and send scan.
2. Disconnect from bluetooth socket randomly. (i.e. move outside bluetooth range of device)
3. Attempt to send again.

The second sent scan will be missed due to the socket being invalid.

This PR has BinaryEye try to send the scan a second time whenever there is a failure due to a previously connected bluetooth socket so that the user does not have to physically scan twice.