### PR TITLE
allow file input from share menu

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,7 +62,7 @@
 			<intent-filter android:label="@string/compose_barcode">
 				<action android:name="android.intent.action.SEND"/>
 				<category android:name="android.intent.category.DEFAULT"/>
-				<data android:mimeType="text/plain"/>
+				<data android:mimeType="text/*"/>
 			</intent-filter>
 			<intent-filter>
 				<action android:name="com.google.zxing.client.android.SCAN"/>


### PR DESCRIPTION
BinaryEye allows the user to input data using the Share menu and create QR codes from it.
This however only works if the text data is included in the share intent. Sharing a file (e.g. from the file explorer) just leads to the main page.

I updated the `handleSendText` method to support both types of intents. I also extended the accepted file types to `text/*` to also accept VCards
and other text-based files.

Possible applications for this new feature are
- Share contacts from your address book as QR codes (fixes #73)
- Create QR codes from text files out of the file explorer

Tested with the default Android file browser and the contacts app on LineageOS.
