### PR TITLE
Fix chronological order of scans taken less than 1 second apart

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/database/Scan.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/database/Scan.kt
@@ -190,7 +190,7 @@ private fun getDateTime(
 		"yyyy-MM-dd HH:mm:ss"
 	},
 	time
-).toString()
+).toString() + String.format(":%03d", (time % 1000))
 
 private fun Parcel.writeSizedByteArray(array: ByteArray?) {
 	val size = array?.size ?: 0


### PR DESCRIPTION
Prior to this commit scanning codes in rapid succession would result in multiple `Scan` instances ending up with the same `dateTime` value since the format string only includes date and time down to seconds.

This is a problem because the database query orders scans by their `dateTime` value, when collisions occur their true chronological order is lost.

To correct this I have extended the `dateTime` string to include time down to milliseconds.

You can check this behavior with something like:
```bash
while :
do
  qrencode -t utf8 1; sleep 0.5
  qrencode -t utf8 2; sleep 0.5
  qrencode -t utf8 3; sleep 0.5
done
```
In continuous scan mode with a delay of 1/4 second and rejecting consecutive duplicates the difference is clear:
| Before | After |
|-----------|---------|
| ![Before](https://github.com/user-attachments/assets/6c009e66-beec-4051-88da-ec8c8fb37643) | ![After](https://github.com/user-attachments/assets/c6c985d0-66fa-4c5b-91af-dabec9525409) | 