### PR TITLE
Update README.md explain non-clickable binaryeye:// url

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ ZXing can generate the following barcode formats:
 You can invoke Binary Eye with a web URI intent from anything that can
 open URIs. There are two options:
 
-1. [binaryeye://scan](binaryeye://scan)
+1. [binaryeye://scan](binaryeye://scan)       (note: Github Markdown does not render this as clickable link)
 2. [http(s)://markusfisch.de/BinaryEye](http://markusfisch.de/BinaryEye)
 
 If you want to get the scanned contents, you can add a `ret` query


### PR DESCRIPTION
See https://github.com/github/markup/issues/933

I think the best we can do is make an explicit notice