### PR TITLE
Support deep links to encode content via web links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,22 @@ testscan:
 testencode:
 	adb shell am start -a android.intent.action.VIEW \
 		-c android.intent.category.BROWSABLE \
-		-d 'binaryeye://encode?content=Test\&format=QRCode'
+		-d 'binaryeye://encode?content=Test\&format=QR_CODE'
+
+testencodenotqr:
+	adb shell am start -a android.intent.action.VIEW \
+		-c android.intent.category.BROWSABLE \
+		-d 'binaryeye://encode?content=Test\&format=DATA_MATRIX'
 
 testencodeexec:
 	adb shell am start -a android.intent.action.VIEW \
 		-c android.intent.category.BROWSABLE \
-		-d 'binaryeye://encode?content=Test\&format=QRCode\&execute=true'
+		-d 'binaryeye://encode?content=Test\&format=QR_CODE\&execute'
+
+testencodeurl:
+	adb shell am start -a android.intent.action.VIEW \
+		-c android.intent.category.BROWSABLE \
+		-d 'http://markusfisch.de/encode?content=Test\&format=QR_CODE'
 
 testurl:
 	adb shell am start -a android.intent.action.VIEW \

--- a/README.md
+++ b/README.md
@@ -111,9 +111,11 @@ Supported symbols are:
 You can use the URL arguments `content` and `format` to automatically
 preset this data. For example:
 
-[binaryeye://encode?content=Test&format=QRCODE](binaryeye://encode?content=Test&format=QRCODE)
+1. [binaryeye://encode?content=Test&format=QR_CODE](binaryeye://encode?content=Test&format=QR_CODE)
+2. [http(s)://markusfisch.de/encode?content=Test&format=QR_CODE](http://markusfisch.de/encode?content=Test&format=QR_CODE)
+3. [http(s)://markusfisch.de/encode?content=Test&format=DATA_MATRIX](http://markusfisch.de/encode?content=Test2&format=DATA_MATRIX&execute)
 
-If you want the code to be generated immediately, add `execute=true`.
+If you want the code to be generated immediately, add `execute=true` (or just `execute`).
 
 ## Intents
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,4 +86,5 @@ dependencies {
 
 	// Testing
 	testImplementation 'junit:junit:4.13.2'
+	testImplementation 'org.robolectric:robolectric:4.14'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -114,6 +114,15 @@
 		<activity
 			android:name=".activity.MainActivity"
 			android:exported="true">
+			<intent-filter android:autoVerify="true">
+				<action android:name="android.intent.action.VIEW"/>
+				<category android:name="android.intent.category.DEFAULT"/>
+				<category android:name="android.intent.category.BROWSABLE"/>
+				<data android:host="markusfisch.de"/>
+				<data android:pathPrefix="/encode"/>
+				<data android:scheme="http"/>
+				<data android:scheme="https"/>
+			</intent-filter>
 			<intent-filter>
 				<action android:name="android.intent.action.VIEW"/>
 				<category android:name="android.intent.category.DEFAULT"/>

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
@@ -39,6 +39,7 @@ import de.markusfisch.android.binaryeye.graphics.mapPosition
 import de.markusfisch.android.binaryeye.graphics.setFrameRoi
 import de.markusfisch.android.binaryeye.graphics.setFrameToView
 import de.markusfisch.android.binaryeye.media.releaseToneGenerators
+import de.markusfisch.android.binaryeye.net.isScanDeeplink
 import de.markusfisch.android.binaryeye.net.sendAsync
 import de.markusfisch.android.binaryeye.net.urlEncode
 import de.markusfisch.android.binaryeye.preference.Preferences
@@ -221,7 +222,7 @@ class CameraActivity : AppCompatActivity() {
 				returnResult = true
 			}
 
-			intent?.dataString?.isReturnUrl() == true -> {
+			intent?.dataString?.let(::isScanDeeplink) == true -> {
 				finishAfterShowingResult = true
 				returnUrlTemplate = intent.data?.getQueryParameter("ret")
 			}
@@ -837,12 +838,6 @@ private fun getReturnIntent(result: Result) = Intent().apply {
 		putExtra("SCAN_RESULT_BYTES", result.rawBytes)
 	}
 }
-
-private fun String.isReturnUrl() = listOf(
-	"binaryeye://scan",
-	"http://markusfisch.de/BinaryEye",
-	"https://markusfisch.de/BinaryEye"
-).firstOrNull { startsWith(it) } != null
 
 private fun completeUrl(urlTemplate: String, result: Result) = Uri.parse(
 	urlTemplate

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/MainActivity.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/MainActivity.kt
@@ -20,6 +20,7 @@ import de.markusfisch.android.binaryeye.fragment.DecodeFragment
 import de.markusfisch.android.binaryeye.fragment.EncodeFragment
 import de.markusfisch.android.binaryeye.fragment.HistoryFragment
 import de.markusfisch.android.binaryeye.fragment.PreferencesFragment
+import de.markusfisch.android.binaryeye.net.isEncodeDeeplink
 import de.markusfisch.android.binaryeye.view.colorSystemAndToolBars
 import de.markusfisch.android.binaryeye.view.initBars
 
@@ -82,12 +83,13 @@ class MainActivity : AppCompatActivity() {
 				intent.hasExtra(PREFERENCES) -> PreferencesFragment()
 				intent.hasExtra(HISTORY) -> HistoryFragment()
 
-				intent.dataString?.startsWith("binaryeye://encode") == true -> {
+				intent.dataString?.let(::isEncodeDeeplink) == true -> {
 					val uri = Uri.parse(intent.dataString)
 					EncodeFragment.newInstance(
-						uri.getQueryParameter("content"),
-						uri.getQueryParameter("format"),
-						!uri.getQueryParameter("execute").isNullOrEmpty()
+						content = uri.getQueryParameter("content"),
+						format = uri.getQueryParameter("format")?.uppercase(),
+						execute = uri.getQueryParameter("execute")
+							.let { it == "" || it.toBoolean() }
 					)
 				}
 

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/content/Barcode.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/content/Barcode.kt
@@ -61,7 +61,7 @@ fun String?.toErrorCorrectionInt() = when (this) {
 	else -> -1
 }
 
-abstract class Barcode<T>(
+sealed class Barcode<T>(
 	val content: T,
 	val format: BarcodeFormat,
 	val colors: BarcodeColors
@@ -96,6 +96,12 @@ abstract class Barcode<T>(
 	}
 
 	protected abstract fun toText(): String
+
+	fun textOrHex(): String = when (content) {
+		is String -> content
+		is ByteArray -> content.toHexString()
+		else -> throw IllegalArgumentException("Illegal arguments")
+	}
 }
 
 class ContentBarcode<T>(

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/fragment/BarcodeFragment.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/fragment/BarcodeFragment.kt
@@ -29,10 +29,12 @@ import de.markusfisch.android.binaryeye.content.ContentBarcode
 import de.markusfisch.android.binaryeye.content.copyToClipboard
 import de.markusfisch.android.binaryeye.content.shareFile
 import de.markusfisch.android.binaryeye.content.shareText
+import de.markusfisch.android.binaryeye.content.toHexString
 import de.markusfisch.android.binaryeye.database.toScan
 import de.markusfisch.android.binaryeye.io.addSuffixIfNotGiven
 import de.markusfisch.android.binaryeye.io.toSaveResult
 import de.markusfisch.android.binaryeye.io.writeExternalFile
+import de.markusfisch.android.binaryeye.net.createEncodeDeeplink
 import de.markusfisch.android.binaryeye.os.getScreenBrightness
 import de.markusfisch.android.binaryeye.os.setScreenBrightness
 import de.markusfisch.android.binaryeye.view.doOnApplyWindowInsets
@@ -221,10 +223,12 @@ class BarcodeFragment : Fragment() {
 			}
 
 			R.id.copy_to_clipboard -> {
-				context.apply {
-					copyToClipboard(barcode.text())
-					toast(R.string.copied_to_clipboard)
-				}
+				copyToClipboard(barcode.text())
+				true
+			}
+
+			R.id.copy_as_deeplink -> {
+				copyToClipboard(deeplinkToCopy())
 				true
 			}
 
@@ -256,6 +260,18 @@ class BarcodeFragment : Fragment() {
 			else -> super.onOptionsItemSelected(item)
 		}
 	}
+
+	private fun copyToClipboard(text: String, isSensitive: Boolean = false) {
+		activity?.apply {
+			copyToClipboard(text, isSensitive)
+			toast(R.string.copied_to_clipboard)
+		}
+	}
+
+	private fun deeplinkToCopy() = createEncodeDeeplink(
+		format = barcode.format.name,
+		content = barcode.textOrHex(),
+	)
 
 	private fun Context.pickFileType(
 		title: Int,

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/fragment/DecodeFragment.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/fragment/DecodeFragment.kt
@@ -54,6 +54,7 @@ import de.markusfisch.android.binaryeye.database.Scan
 import de.markusfisch.android.binaryeye.io.askForFileName
 import de.markusfisch.android.binaryeye.io.toSaveResult
 import de.markusfisch.android.binaryeye.io.writeExternalFile
+import de.markusfisch.android.binaryeye.net.createEncodeDeeplink
 import de.markusfisch.android.binaryeye.view.hideSoftKeyboard
 import de.markusfisch.android.binaryeye.view.setPaddingFromWindowInsets
 import de.markusfisch.android.binaryeye.widget.toast
@@ -473,6 +474,12 @@ class DecodeFragment : Fragment() {
 				true
 			}
 
+			R.id.copy_as_deeplink -> {
+				copyToClipboard(deeplinkToCopy())
+				maybeBackOrFinish()
+				true
+			}
+
 			R.id.share -> {
 				context?.apply {
 					shareText(textOrHex())
@@ -519,6 +526,11 @@ class DecodeFragment : Fragment() {
 	} else {
 		content
 	}
+
+	private fun deeplinkToCopy() = createEncodeDeeplink(
+		format = format,
+		content = textOrHex(),
+	)
 
 	private fun copyPasswordToClipboard() {
 		val ac = action

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/net/BinaryEyeDeeplink.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/net/BinaryEyeDeeplink.kt
@@ -1,0 +1,30 @@
+package de.markusfisch.android.binaryeye.net
+
+import android.net.Uri
+
+private const val SCHEME = "binaryeye"
+private const val HOSTNAME = "markusfisch.de"
+private const val ENCODE_PATH = "encode"
+
+fun isScanDeeplink(text: String) = listOf(
+	"$SCHEME://scan",
+	"http://$HOSTNAME/BinaryEye",
+	"https://$HOSTNAME/BinaryEye"
+).any { text.startsWith(it) }
+
+fun isEncodeDeeplink(text: String) = listOf(
+	"$SCHEME://$ENCODE_PATH",
+	"http://$HOSTNAME/$ENCODE_PATH",
+	"https://$HOSTNAME/$ENCODE_PATH"
+).any { text.startsWith(it) }
+
+fun createEncodeDeeplink(format: String, content: String): String {
+	return Uri.Builder()
+		.scheme("https")
+		.authority(HOSTNAME)
+		.appendPath(ENCODE_PATH)
+		.appendQueryParameter("format", format)
+		.appendQueryParameter("content", content)
+		.build()
+			.toString()
+}

--- a/app/src/main/res/drawable/ic_action_link.xml
+++ b/app/src/main/res/drawable/ic_action_link.xml
@@ -1,0 +1,3 @@
+<vector android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24.0" android:viewportWidth="24.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M3.9,12c0,-1.71 1.39,-3.1 3.1,-3.1h4L11,7L7,7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h4v-1.9L7,15.1c-1.71,0 -3.1,-1.39 -3.1,-3.1zM8,13h8v-2L8,11v2zM17,7h-4v1.9h4c1.71,0 3.1,1.39 3.1,3.1s-1.39,3.1 -3.1,3.1h-4L13,17h4c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5z"/>
+</vector>

--- a/app/src/main/res/menu/fragment_barcode.xml
+++ b/app/src/main/res/menu/fragment_barcode.xml
@@ -12,6 +12,11 @@
 		android:icon="@drawable/ic_action_copy"
 		material:showAsAction="ifRoom"/>
 	<item
+		android:id="@+id/copy_as_deeplink"
+		android:title="@string/copy_as_deeplink"
+		android:icon="@drawable/ic_action_link"
+		material:showAsAction="ifRoom"/>
+	<item
 		android:id="@+id/export_to_file"
 		android:title="@string/export_to_file"
 		android:icon="@drawable/ic_action_save"

--- a/app/src/main/res/menu/fragment_decode.xml
+++ b/app/src/main/res/menu/fragment_decode.xml
@@ -19,6 +19,11 @@
 		android:icon="@drawable/ic_action_copy"
 		material:showAsAction="ifRoom"/>
 	<item
+		android:id="@+id/copy_as_deeplink"
+		android:title="@string/copy_as_deeplink"
+		android:icon="@drawable/ic_action_link"
+		material:showAsAction="ifRoom"/>
+	<item
 		android:id="@+id/share"
 		android:title="@string/share"
 		android:icon="@drawable/ic_action_share"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -45,6 +45,7 @@
 	<string name="share_file">مشاركة كملف</string>
 	<string name="share_as">مشاركة كـ؟</string>
 	<string name="copy_to_clipboard">نسخ إلى الحافظة</string>
+	<string name="copy_as_deeplink">نسخ كرابط عميق</string>
 	<string name="copied_to_clipboard">تم النسخ إلى الحافظة</string>
 	<string name="copy_password">نسخ كلمة المرور إلى الحافظة</string>
 	<string name="open_url">فتح الرابط</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">Споделяне като файл</string>
 	<string name="share_as">Сподели като?</string>
 	<string name="copy_to_clipboard">Копиране в клипборда</string>
+	<string name="copy_as_deeplink">Копиране като дийп линк</string>
 	<string name="copied_to_clipboard">Копирано в клипборда</string>
 	<string name="copy_password">Копиране на паролата в клипборда</string>
 	<string name="open_url">Отворете URL(Линк)</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">ফাইল হিসেবে ভাগাভাগি</string>
 	<string name="share_as">ভাগ করার মাধ্যম</string>
 	<string name="copy_to_clipboard">ক্লিপবোর্ডে অনুলিপি</string>
+	<string name="copy_as_deeplink">ডিপলিংক হিসেবে কপি করুন</string>
 	<string name="copied_to_clipboard">ক্লিপবোর্ডে অনুলিপিত</string>
 	<string name="copy_password">ক্লিপবোর্ডে পাসওয়ার্ড অনুলিপি করো</string>
 	<string name="open_url">ইউআরএল খুলো</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -43,6 +43,7 @@
 	<string name="share_file">Sdílet jako soubor</string>
 	<string name="share_as">Sdílet jako</string>
 	<string name="copy_to_clipboard">Zkopírovat do schránky</string>
+	<string name="copy_as_deeplink">Kopírovat jako deeplink</string>
 	<string name="copied_to_clipboard">Zkopírováno do schránky</string>
 	<string name="copy_password">Zkopírovat heslo do schránky</string>
 	<string name="open_url">Otevřít URL</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">Del som fil</string>
 	<string name="share_as">Del som?</string>
 	<string name="copy_to_clipboard">Kopier til udklipsholder</string>
+	<string name="copy_as_deeplink">Kopiér som deeplink</string>
 	<string name="copied_to_clipboard">Kopieret til udklipsholder</string>
 	<string name="copy_password">Kopier adgangskode til udklipsholderen</string>
 	<string name="open_url">Åbn URL</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">Als Datei teilen</string>
 	<string name="share_as">Teilen als?</string>
 	<string name="copy_to_clipboard">In die Zwischenablage kopieren</string>
+	<string name="copy_as_deeplink">Als Deeplink kopieren</string>
 	<string name="copied_to_clipboard">Inhalt wurde in die Zwischenablage kopiert</string>
 	<string name="copy_password">Passwort in die Zwischenablage kopieren</string>
 	<string name="open_url">URL öffnen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">Compartir como archivo</string>
 	<string name="share_as">¿Compartir como?</string>
 	<string name="copy_to_clipboard">Copiar al portapapeles</string>
+	<string name="copy_as_deeplink">Copiar como deeplink</string>
 	<string name="copied_to_clipboard">Copiado al portapapeles</string>
 	<string name="copy_password">Copiar contraseña al portapapeles</string>
 	<string name="open_url">Abrir URL</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">اشتراک گذاری به عنوان فایل</string>
 	<string name="share_as">هم‌رسانی به عنوان؟</string>
 	<string name="copy_to_clipboard">رونوشت به تخه‌گیره</string>
+	<string name="copy_as_deeplink">کپی به صورت پیوند عمیق</string>
 	<string name="copied_to_clipboard">به تخته‌گیره رونوشت شد</string>
 	<string name="copy_password">رونوشت گذرواژه به تخته‌گیره</string>
 	<string name="open_url">گشودن نشانی</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">Partager en tant que fichier</string>
 	<string name="share_as">Partager en tant que ?</string>
 	<string name="copy_to_clipboard">Copier dans le presse-papiers</string>
+	<string name="copy_as_deeplink">Copier sous forme de lien profond</string>
 	<string name="copied_to_clipboard">Copié dans le presse-papiers</string>
 	<string name="copy_password">Copier le mot de passe dans le presse-papiers</string>
 	<string name="open_url">Ouvrir l\'URL</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">Fájlként megosztás</string>
 	<string name="share_as">Megosztja másként?</string>
 	<string name="copy_to_clipboard">Másolás a vágólapra</string>
+	<string name="copy_as_deeplink">Másolás mélyhivatkozásként</string>
 	<string name="copied_to_clipboard">Vágólapra helyezés</string>
 	<string name="copy_password">Jelszó másolása a vágólapra</string>
 	<string name="open_url">URL megnyitása</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -40,6 +40,7 @@
 	<string name="share_file">Dijeli kao datoteku</string>
 	<string name="share_as">Bagikan sebagai?</string>
 	<string name="copy_to_clipboard">Salin ke clipboard</string>
+	<string name="copy_as_deeplink">Salin sebagai tautan langsung</string>
 	<string name="copied_to_clipboard">Disalin ke clipboard</string>
 	<string name="copy_password">Salin sandi ke clipboard</string>
 	<string name="open_url">Buka url</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">Condividi come file</string>
 	<string name="share_as">Condividi come?</string>
 	<string name="copy_to_clipboard">Copia negli Appunti</string>
+	<string name="copy_as_deeplink">Copia come deeplink</string>
 	<string name="copied_to_clipboard">Copiato negli Appunti</string>
 	<string name="copy_password">Copia password negli Appunti</string>
 	<string name="open_url">Apri URL</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -40,6 +40,7 @@
 	<string name="share_file">ファイルとして共有</string>
 	<string name="share_as">画像形式を選択</string>
 	<string name="copy_to_clipboard">クリップボードにコピー</string>
+	<string name="copy_as_deeplink">ディープリンクとしてコピー</string>
 	<string name="copied_to_clipboard">クリップボードにコピーされました</string>
 	<string name="copy_password">クリップボードにパスワードをコピー</string>
 	<string name="open_url">URLを開く</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">გაზიარეთ ფაილის სახით</string>
 	<string name="share_as">გაზიარე როგორ?</string>
 	<string name="copy_to_clipboard">გაცვლის ბუფერში კოპირება</string>
+	<string name="copy_as_deeplink">კოპირება deeplink-ის სახით</string>
 	<string name="copied_to_clipboard">კოპირებულია გაცვლის ბუფერში</string>
 	<string name="copy_password">პაროლის გაცვლით ბუფერში კოპირება</string>
 	<string name="open_url">ბმულის გახსნა</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -40,6 +40,7 @@
 	<string name="share_file">파일로 공유</string>
 	<string name="share_as">공유할까요?</string>
 	<string name="copy_to_clipboard">클립보드에 복사</string>
+	<string name="copy_as_deeplink">딥링크로 복사</string>
 	<string name="copied_to_clipboard">클립보드에 복사되었습니다</string>
 	<string name="copy_password">클립보드에 비밀번호 복사</string>
 	<string name="open_url">Open url</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">Delen als bestand</string>
 	<string name="share_as">Delen als?</string>
 	<string name="copy_to_clipboard">Naar klembord kopiëren</string>
+	<string name="copy_as_deeplink">Kopieer als deeplink</string>
 	<string name="copied_to_clipboard">Naar klembord gekopieerd</string>
 	<string name="copy_password">Kopieer wachtwoord naar klembord</string>
 	<string name="open_url">URL openen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -8,6 +8,7 @@
 	<string name="content">Zawartość</string>
 	<string name="copied_to_clipboard">Skopiowano do schowka</string>
 	<string name="copy_to_clipboard">Skopiuj do schowka</string>
+	<string name="copy_as_deeplink">Kopiuj jako link bezpośredni</string>
 	<string name="info">Informacje</string>
 	<string name="vcard_add">Dodaj do kontaktów</string>
 	<string name="vevent_add">Dodaj do kalendarza</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">Compartilhar como arquivo</string>
 	<string name="share_as">Compartilhar como?</string>
 	<string name="copy_to_clipboard">Copiar para a área de transferência</string>
+	<string name="copy_as_deeplink">Copiar como link direto</string>
 	<string name="copied_to_clipboard">Copiado para a área de transferência</string>
 	<string name="copy_password">Copiar senha para a área de transferência</string>
 	<string name="open_url">Abrir URL</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -43,6 +43,7 @@
 	<string name="share_file">Поделиться файлом</string>
 	<string name="share_as">Поделиться как?</string>
 	<string name="copy_to_clipboard">Скопировать в буфер обмена</string>
+	<string name="copy_as_deeplink">Копировать как диплинк</string>
 	<string name="copied_to_clipboard">Скопировано в буфер обмена</string>
 	<string name="copy_password">Скопировать пароль в буфер обмена</string>
 	<string name="open_url">Открыть URL</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">Dosya olarak paylaş</string>
 	<string name="share_as">Şöyle paylaş:</string>
 	<string name="copy_to_clipboard">Panoya kopyala</string>
+	<string name="copy_as_deeplink">Derin bağlantı olarak kopyala</string>
 	<string name="copied_to_clipboard">Panoya kopyalandı</string>
 	<string name="copy_password">Parolayı panoya kopyala</string>
 	<string name="open_url">URL\'yi aç</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -42,6 +42,7 @@
 	<string name="share_file">Поділитися файлом</string>
 	<string name="share_as">Поділитися як?</string>
 	<string name="copy_to_clipboard">Копіювати у буфер обміну</string>
+	<string name="copy_as_deeplink">Копіювати як диплінк</string>
 	<string name="copied_to_clipboard">Скопійовано у буфер обміну</string>
 	<string name="copy_password">Копіювати пароль у буфер обміну</string>
 	<string name="open_url">Відкрити URL-адресу</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -40,6 +40,7 @@
 	<string name="share_file">Chia sẻ dưới dạng tập tin</string>
 	<string name="share_as">Chia sẻ dưới định dạng?</string>
 	<string name="copy_to_clipboard">Sao chép</string>
+	<string name="copy_as_deeplink">Sao chép dưới dạng liên kết sâu</string>
 	<string name="copied_to_clipboard">Đã sao chép</string>
 	<string name="copy_password">Sao chép mật khẩu</string>
 	<string name="open_url">Mở đường dẫn</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -40,6 +40,7 @@
 	<string name="share_file">以文件形式分享</string>
 	<string name="share_as">以何种方式分享？</string>
 	<string name="copy_to_clipboard">复制到剪贴板</string>
+	<string name="copy_as_deeplink">复制为深层链接</string>
 	<string name="copied_to_clipboard">已复制到剪贴板</string>
 	<string name="copy_password">复制密码到剪贴板</string>
 	<string name="open_url">打开链接</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -40,6 +40,7 @@
 	<string name="share_file">分享檔案</string>
 	<string name="share_as">您要以何種方式分享？</string>
 	<string name="copy_to_clipboard">複製到剪貼簿</string>
+	<string name="copy_as_deeplink">複製為深層連結</string>
 	<string name="copied_to_clipboard">已複製到剪貼簿</string>
 	<string name="copy_password">複製密碼到剪貼簿</string>
 	<string name="open_url">開啟連結</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
 	<string name="share_file">Share as file</string>
 	<string name="share_as">Share as?</string>
 	<string name="copy_to_clipboard">Copy to clipboard</string>
+	<string name="copy_as_deeplink">Copy as deeplink</string>
 	<string name="copied_to_clipboard">Copied to clipboard</string>
 	<string name="copy_password">Copy password into clipboard</string>
 	<string name="open_url">Open URL</string>

--- a/app/src/test/kotlin/de/markusfisch/android/binaryeye/net/BinaryEyeDeeplinkTest.kt
+++ b/app/src/test/kotlin/de/markusfisch/android/binaryeye/net/BinaryEyeDeeplinkTest.kt
@@ -1,0 +1,75 @@
+package de.markusfisch.android.binaryeye.net
+
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BinaryEyeDeeplinkTest {
+
+    @Test
+    fun isScanDeeplinkTests() {
+        // Test for binaryeye://scan
+        assertEquals(true, isScanDeeplink("binaryeye://scan"))
+        assertEquals(true, isScanDeeplink("binaryeye://scan?param=value"))
+        
+        // Test for http://markusfisch.de/BinaryEye
+        assertEquals(true, isScanDeeplink("http://markusfisch.de/BinaryEye"))
+        assertEquals(true, isScanDeeplink("http://markusfisch.de/BinaryEye?param=value"))
+        
+        // Test for https://markusfisch.de/BinaryEye
+        assertEquals(true, isScanDeeplink("https://markusfisch.de/BinaryEye"))
+        assertEquals(true, isScanDeeplink("https://markusfisch.de/BinaryEye?param=value"))
+        
+        // Negative tests
+        assertEquals(false, isScanDeeplink("binaryeye://encode"))
+        assertEquals(false, isScanDeeplink("http://markusfisch.de/encode"))
+        assertEquals(false, isScanDeeplink("https://markusfisch.de/encode"))
+        assertEquals(false, isScanDeeplink("http://example.com"))
+        assertEquals(false, isScanDeeplink(""))
+    }
+
+    @Test
+    fun isEncodeDeeplinkTests() {
+        // Test for binaryeye://encode
+        assertEquals(true, isEncodeDeeplink("binaryeye://encode"))
+        assertEquals(true, isEncodeDeeplink("binaryeye://encode?param=value"))
+        
+        // Test for http://markusfisch.de/encode
+        assertEquals(true, isEncodeDeeplink("http://markusfisch.de/encode"))
+        assertEquals(true, isEncodeDeeplink("http://markusfisch.de/encode?param=value"))
+        
+        // Test for https://markusfisch.de/encode
+        assertEquals(true, isEncodeDeeplink("https://markusfisch.de/encode"))
+        assertEquals(true, isEncodeDeeplink("https://markusfisch.de/encode?param=value"))
+        
+        // Negative tests
+        assertEquals(false, isEncodeDeeplink("binaryeye://scan"))
+        assertEquals(false, isEncodeDeeplink("http://markusfisch.de/BinaryEye"))
+        assertEquals(false, isEncodeDeeplink("https://markusfisch.de/BinaryEye"))
+        assertEquals(false, isEncodeDeeplink("http://example.com"))
+        assertEquals(false, isEncodeDeeplink(""))
+    }
+
+    @Test
+    fun createEncodeDeeplinkTests() {
+        // Basic test
+        assertEquals(
+            "https://markusfisch.de/encode?format=QR_CODE&content=test",
+            createEncodeDeeplink("QR_CODE", "test")
+        )
+        
+        // Test with special characters in content
+        assertEquals(
+            "https://markusfisch.de/encode?format=QR_CODE&content=test%20with%20spaces",
+            createEncodeDeeplink("QR_CODE", "test with spaces")
+        )
+        
+        // Test with different barcode format
+        assertEquals(
+            "https://markusfisch.de/encode?format=CODE_128&content=123456",
+            createEncodeDeeplink("CODE_128", "123456")
+        )
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx1536m
 kotlin.code.style=official
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.useAndroidX=true


### PR DESCRIPTION
Recently, I wanted to store QR codes in my notes as text instead of images, and that got me thinking about this feature in BinaryEye.

I added support for opening `barcode://encode` via an HTTP deep link, as well as an action to copy the deep link to the clipboard. I still need an icon for this action — any suggestions on how to create one would be helpful.

Also, please take a look at the intent filter for the `EncodeBinaryEye` host — maybe there’s a better way to name it?

p.s. Translation i'll do later (with ChatGPT ^_^)

п.с. Use cases where I now use this feature:
* Storing discount cards for grocery stores.
* QR code for fitness club.