### PR TITLE
Fix to Make "Pick image file" more accessible #549

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
@@ -18,6 +18,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
+import android.widget.Button
 import android.widget.EditText
 import android.widget.SeekBar
 import de.markusfisch.android.binaryeye.R
@@ -70,6 +71,7 @@ class CameraActivity : AppCompatActivity() {
 	private lateinit var detectorView: DetectorView
 	private lateinit var zoomBar: SeekBar
 	private lateinit var flashFab: FloatingActionButton
+	private lateinit var pickImageButton: Button
 
 	private var formatsToRead = setOf<BarcodeFormat>()
 	private var frameMetrics = FrameMetrics()
@@ -135,10 +137,12 @@ class CameraActivity : AppCompatActivity() {
 		detectorView = findViewById(R.id.detector_view) as DetectorView
 		zoomBar = findViewById(R.id.zoom) as SeekBar
 		flashFab = findViewById(R.id.flash) as FloatingActionButton
+		pickImageButton = findViewById(R.id.pick_image_button) as Button
 
 		initCameraView()
 		initZoomBar()
 		initDetectorView()
+		initPickImageButton()
 
 		if (intent?.action == Intent.ACTION_SEND &&
 			intent.type?.startsWith("text/") == true
@@ -301,19 +305,6 @@ class CameraActivity : AppCompatActivity() {
 
 			R.id.history -> {
 				startActivity(MainActivity.getHistoryIntent(this))
-				true
-			}
-
-			R.id.pick_file -> {
-				startActivityForResult(
-					Intent.createChooser(
-						Intent(Intent.ACTION_GET_CONTENT).apply {
-							type = "image/*"
-						},
-						getString(R.string.pick_image_file)
-					),
-					PICK_FILE_RESULT_CODE
-				)
 				true
 			}
 
@@ -718,6 +709,20 @@ class CameraActivity : AppCompatActivity() {
 		} else {
 			flashFab.setImageResource(R.drawable.ic_action_flash)
 			flashFab.setOnClickListener { toggleTorchMode() }
+		}
+	}
+
+	private fun initPickImageButton() {
+		pickImageButton.setOnClickListener {
+			startActivityForResult(
+				Intent.createChooser(
+					Intent(Intent.ACTION_GET_CONTENT).apply {
+						type = "image/*"
+					},
+					getString(R.string.pick_image_file)
+				),
+				PICK_FILE_RESULT_CODE
+			)
 		}
 	}
 

--- a/app/src/main/res/layout/activity_camera.xml
+++ b/app/src/main/res/layout/activity_camera.xml
@@ -29,5 +29,21 @@
 			android:id="@+id/flash"
 			android:contentDescription="@string/toggle_flash"
 			android:src="@drawable/ic_action_flash"/>
+		<Button
+			android:id="@+id/pick_image_button"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_gravity="bottom|center_horizontal"
+			android:layout_marginBottom="80dp"
+			android:background="@drawable/button_raised"
+			android:drawableLeft="@drawable/ic_action_pick_file"
+			android:drawableStart="@drawable/ic_action_pick_file"
+			android:drawablePadding="8dp"
+			android:padding="12dp"
+			android:text="@string/pick_image_file"
+			android:textColor="@color/button_text"
+			android:textSize="14sp"
+			android:elevation="4dp"
+			android:contentDescription="@string/pick_image_file"/>
 	</android.support.design.widget.CoordinatorLayout>
 </merge>

--- a/app/src/main/res/menu/activity_camera.xml
+++ b/app/src/main/res/menu/activity_camera.xml
@@ -12,11 +12,6 @@
 		android:icon="@drawable/ic_action_create"
 		material:showAsAction="ifRoom"/>
 	<item
-		android:id="@+id/pick_file"
-		android:title="@string/pick_image_file"
-		android:icon="@drawable/ic_action_pick_file"
-		material:showAsAction="ifRoom"/>
-	<item
 		android:id="@+id/switch_camera"
 		android:title="@string/switch_camera"
 		android:icon="@drawable/ic_action_switch_camera"


### PR DESCRIPTION
# PR: Move "Pick Image File" to Main Screen with Improved UI

## Implementation
- **Moved "Pick Image File" to the main screen**  
  Now directly accessible without navigating through the overflow menu.
- **Created a clean, professional UI**  
  White rectangular button with icon and text instead of a floating action button.  
  *Design inspired by the already present buttons on the same screen.*
- **Optimal positioning**  
  Centered horizontally and placed just above the zoom bar for easy access.
- **Maintained existing functionality**  
  Same file picker behavior, just more accessible.
- **Removed redundant menu item**  
  Cleaned up the overflow menu since the feature is now directly available.

## Key Changes Made
- **Layout:** Added centered button in `activity_camera.xml`
- **Activity:** Updated `CameraActivity.kt` to handle the new button
- **Menu:** Removed the old menu item to avoid duplication
- **UX:** Enhanced user experience with direct access to a frequently used feature

## Result
Users can now easily access the **"Pick Image File"** feature directly from the main scanning screen with a single tap, improving workflow efficiency significantly. The button is well-positioned, visually clear, and maintains the app’s design consistency.  

This feature is now as accessible as the **"Compose Barcode"** functionality, addressing the original issue perfectly! 🎯
