### PR TITLE
Changed SecurityException to Exception in BluetoothSender

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/bluetooth/BluetoothSender.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/bluetooth/BluetoothSender.kt
@@ -70,7 +70,7 @@ private fun connect(deviceName: String, onceMore: Boolean): Boolean = try {
 	writer = socket?.outputStream?.writer()
 	isConnected = true
 	true
-} catch (_: SecurityException) {
+} catch (_: Exception) {
 	if (onceMore) {
 		connect(deviceName, false)
 	} else {


### PR DESCRIPTION
`socket?.connect()` can throw IOException errors. 

This specifically occurs on Windows when the bluetooth service gets killed and restarted in the background with default Windows settings.  