### PR TITLE
Clear search term on empty not on cancel

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/activity/CameraActivity.kt
@@ -432,14 +432,14 @@ class CameraActivity : AppCompatActivity() {
 				val term = editText.text.toString().trim()
 				if (!term.isEmpty()) {
 					searchTerm = term.toRegex()
-					ignoreNext = null
+				} else {
+					searchTerm = null
 				}
+				ignoreNext = null
 				updateTitle()
 			}
 			.setNegativeButton(android.R.string.cancel) { _, _ ->
-				searchTerm = null
-				ignoreNext = null
-				updateTitle()
+				// do not change anything on cancel
 			}
 			.show()
 	}


### PR DESCRIPTION
I love using BinaryEye as a simple and fast QR scanner without bloatware.

However the dialog for finding a term in the QR code currently behaves in a very unexpected way for me as it clears the search term when I press "Cancel". Additionally, providing an empty input is silently ignored and does not reset the feature.

"Cancel" usually indicates "stop the dialog and don't change anything" and not "change settings to empty". Accepting input, but silently ignoring is also not good.

Therefore this PR modifies the dialog so that:
* Cancel just leaves the dialog and does not change settings
* The feature can be reset by providing an empty value, which is the far more intuitive way for me

This way, it behaves much more intuitively and matches what most other dialogs on Android provide.