### PR TITLE
Mapping.kt: Fix crash on upgrades due to missing DATA_BAR entry

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/zxingcpp/Mapping.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/zxingcpp/Mapping.kt
@@ -10,6 +10,7 @@ val oldToNewFormatNames = mapOf(
 	"PZN" to "PZN",
 	"CODE_93" to "Code93",
 	"CODE_128" to "Code128",
+	"DATA_BAR" to "DataBar",
 	"DATA_BAR_OMNI" to "DataBarOmni",
 	"DATA_BAR_STK" to "DataBarStk",
 	"DATA_BAR_LTD" to "DataBarLtd",


### PR DESCRIPTION
Commit 73047cdee61c83214392934bf9895d640f7e65f6 merged the old `migrateToNativeFormatNames()` and `migrateBarcodeFormatName()` mapping functions, but the new map was based on the former, which happened to be missing the entry for `DATA_BAR`.

Fixes: #636

---

I encountered the crash after upgrading to 1.72.0 with the following shared preferences file in `/data/data/de.markusfisch.android.binaryeye/de.markusfisch.android.binaryeye_preferences.xml`. I tested this fix by creating the same shared preferences file in a debug build's data directory. The entry was successfully migrated to `<string>DataBar</string>` with the fix instead of crashing.

```xml
<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
<map>
    <boolean name="beep" value="false" />
    <float name="preview_scale" value="0.0" />
    <boolean name="show_crop_handle" value="true" />
    <boolean name="DataBarStk_added" value="true" />
    <boolean name="vibrate" value="true" />
    <int name="zoom_level" value="0" />
    <boolean name="show_toast_in_bulk_mode" value="true" />
    <boolean name="expand_escape_sequences" value="true" />
    <boolean name="use_history" value="false" />
    <boolean name="copy_immediately" value="false" />
    <string name="show_checksum"></string>
    <boolean name="DataBarExpStk_added" value="true" />
    <boolean name="show_crosshairs" value="false" />
    <boolean name="welcome_shown" value="true" />
    <string name="custom_locale"></string>
    <boolean name="send_scan_active" value="false" />
    <boolean name="DXFilmEdge_added" value="true" />
    <boolean name="show_hex_dump" value="true" />
    <boolean name="open_immediately" value="false" />
    <string name="send_scan_type">0</string>
    <boolean name="show_recreation" value="true" />
    <string name="send_scan_url"></string>
    <string name="camera_crop_handle:0:0">{&quot;x&quot;:-1,&quot;y&quot;:-1}</string>
    <boolean name="DX_FILM_EDGE_added" value="true" />
    <string name="send_scan_bluetooth_host"></string>
    <boolean name="RMQR_CODE_added" value="true" />
    <string name="beep_tone_name">tone_prop_beep</string>
    <int name="zoom_max" value="99" />
    <set name="formats">
        <string>DATA_BAR</string>
        <string>PZN</string>
        <string>MicroQRCode</string>
        <string>DataBarExpStk</string>
        <string>DataMatrix</string>
        <string>Code39Std</string>
        <string>Code128</string>
        <string>Code39Ext</string>
        <string>DataBarLtd</string>
        <string>Aztec</string>
        <string>DataBarExp</string>
        <string>RMQRCode</string>
        <string>MaxiCode</string>
        <string>DataBarOmni</string>
        <string>UPCE</string>
        <string>UPCA</string>
        <string>DXFilmEdge</string>
        <string>DataBarStk</string>
        <string>EAN8</string>
        <string>PDF417</string>
        <string>Codabar</string>
        <string>QRCode</string>
        <string>Code32</string>
        <string>Code93</string>
        <string>ITF</string>
        <string>EAN13</string>
    </set>
    <boolean name="auto_rotate" value="true" />
    <boolean name="DataBarOmni_added" value="true" />
    <boolean name="brighten_screen" value="false" />
    <int name="index_of_last_selected_format" value="0" />
    <boolean name="show_meta_data" value="true" />
    <boolean name="PZN_added" value="true" />
    <boolean name="Code39Ext_added" value="true" />
    <boolean name="RMQRCode_added" value="true" />
    <string name="ignore_duplicates_name">ignore_consecutive_duplicates</string>
    <boolean name="Code32_added" value="true" />
    <string name="open_with_url"></string>
    <string name="default_search_url"></string>
    <boolean name="DataBarLtd_added" value="true" />
    <boolean name="zoom_by_swiping" value="true" />
    <boolean name="bulk_mode" value="false" />
    <boolean name="free_rotation" value="false" />
    <boolean name="add_quiet_zone" value="true" />
    <boolean name="send_scan_bluetooth" value="false" />
    <boolean name="close_automatically" value="false" />
    <int name="index_of_last_selected_ec_level" value="0" />
    <string name="bulk_mode_delay">500</string>
    <boolean name="Code39Std_added" value="true" />
    <boolean name="try_harder" value="false" />
    <string name="camera_crop_handle:1344:2992">{&quot;x&quot;:1210,&quot;y&quot;:2034}</string>
    <boolean name="DataBarExp_added" value="true" />
    <string name="beep_stream_name">stream_music</string>
</map>
```