### PR TITLE
Share: confirm before opening non-http(s) URIs from scanned content

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/actions/Action.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/actions/Action.kt
@@ -3,6 +3,7 @@ package de.markusfisch.android.binaryeye.actions
 import android.content.Context
 import android.content.Intent
 import de.markusfisch.android.binaryeye.content.execShareIntent
+import de.markusfisch.android.binaryeye.content.execShareIntentWithConsent
 import de.markusfisch.android.binaryeye.content.openUrl
 import de.markusfisch.android.binaryeye.widget.toast
 
@@ -24,7 +25,7 @@ abstract class IntentAction : Action() {
 		if (intent == null) {
 			context.toast(errorMsg)
 		} else {
-			fired = context.execShareIntent(intent)
+			fired = context.execShareIntentWithConsent(intent)
 		}
 	}
 

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/content/Share.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/content/Share.kt
@@ -43,6 +43,38 @@ fun Context.openUrl(url: String, silent: Boolean = false): Boolean {
 }
 
 fun Context.openUri(uri: Uri, silent: Boolean = false): Boolean {
+	if (silent) {
+		return launchUri(uri, silent = true)
+	}
+	val scheme = uri.scheme?.lowercase()
+	val needsExplicitConsent = when (scheme) {
+		"tel", "sms", "smsto", "mms", "mmsto", "mailto" -> true
+		"http", "https", "content", "file", null -> false
+		else -> true
+	}
+	if (!needsExplicitConsent) {
+		return launchUri(uri, silent = false)
+	}
+	val activity = this as? android.app.Activity ?: return launchUri(uri, silent = false)
+	val schemeLabel = when (scheme) {
+		"tel" -> activity.getString(R.string.scheme_label_tel)
+		"sms", "smsto" -> activity.getString(R.string.scheme_label_sms)
+		"mms", "mmsto" -> activity.getString(R.string.scheme_label_mms)
+		"mailto" -> activity.getString(R.string.scheme_label_mailto)
+		else -> activity.getString(R.string.scheme_label_other, scheme ?: "?")
+	}
+	androidx.appcompat.app.AlertDialog.Builder(activity)
+		.setTitle(R.string.scheme_dialog_title)
+		.setMessage(activity.getString(R.string.scheme_dialog_body, schemeLabel, uri.toString()))
+		.setNegativeButton(android.R.string.cancel, null)
+		.setPositiveButton(R.string.scheme_dialog_open) { _, _ ->
+			launchUri(uri, silent = false)
+		}
+		.show()
+	return true
+}
+
+private fun Context.launchUri(uri: Uri, silent: Boolean): Boolean {
 	val intent = Intent(Intent.ACTION_VIEW, uri).apply {
 		if (uri.scheme == "content") {
 			addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/content/Share.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/content/Share.kt
@@ -47,15 +47,41 @@ fun Context.openUri(uri: Uri, silent: Boolean = false): Boolean {
 		return launchUri(uri, silent = true)
 	}
 	val scheme = uri.scheme?.lowercase()
-	val needsExplicitConsent = when (scheme) {
-		"tel", "sms", "smsto", "mms", "mmsto", "mailto" -> true
-		"http", "https", "content", "file", null -> false
-		else -> true
-	}
-	if (!needsExplicitConsent) {
+	if (!schemeNeedsConsent(scheme)) {
 		return launchUri(uri, silent = false)
 	}
 	val activity = this as? android.app.Activity ?: return launchUri(uri, silent = false)
+	confirmSensitiveAction(activity, scheme, uri.toString()) {
+		launchUri(uri, silent = false)
+	}
+	return true
+}
+
+fun Context.execShareIntentWithConsent(intent: Intent): Boolean {
+	val uri = intent.data
+	val scheme = uri?.scheme?.lowercase()
+	if (uri == null || !schemeNeedsConsent(scheme)) {
+		return execShareIntent(intent)
+	}
+	val activity = this as? android.app.Activity ?: return execShareIntent(intent)
+	confirmSensitiveAction(activity, scheme, uri.toString()) {
+		execShareIntent(intent)
+	}
+	return true
+}
+
+private fun schemeNeedsConsent(scheme: String?): Boolean = when (scheme) {
+	"tel", "sms", "smsto", "mms", "mmsto", "mailto" -> true
+	"http", "https", "content", "file", null -> false
+	else -> true
+}
+
+private fun confirmSensitiveAction(
+	activity: android.app.Activity,
+	scheme: String?,
+	uriShown: String,
+	onConfirm: () -> Unit
+) {
 	val schemeLabel = when (scheme) {
 		"tel" -> activity.getString(R.string.scheme_label_tel)
 		"sms", "smsto" -> activity.getString(R.string.scheme_label_sms)
@@ -65,13 +91,10 @@ fun Context.openUri(uri: Uri, silent: Boolean = false): Boolean {
 	}
 	androidx.appcompat.app.AlertDialog.Builder(activity)
 		.setTitle(R.string.scheme_dialog_title)
-		.setMessage(activity.getString(R.string.scheme_dialog_body, schemeLabel, uri.toString()))
+		.setMessage(activity.getString(R.string.scheme_dialog_body, schemeLabel, uriShown))
 		.setNegativeButton(android.R.string.cancel, null)
-		.setPositiveButton(R.string.scheme_dialog_open) { _, _ ->
-			launchUri(uri, silent = false)
-		}
+		.setPositiveButton(R.string.scheme_dialog_open) { _, _ -> onConfirm() }
 		.show()
-	return true
 }
 
 private fun Context.launchUri(uri: Uri, silent: Boolean): Boolean {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -431,4 +431,13 @@
 	<string name="parsed_type_calendar_event">حدث تقويمي</string>
 	<string name="parsed_type_wifi_network">شبكة واي فاي</string>
 	<string name="formatted_json">JSON منسق</string>
+
+	<string name="scheme_dialog_title">السماح بهذا الإجراء؟</string>
+	<string name="scheme_dialog_body">يريد رمز QR هذا فتح %1$s باستخدام:\n\n%2$s</string>
+	<string name="scheme_dialog_open">فتح</string>
+	<string name="scheme_label_tel">تطبيق الهاتف</string>
+	<string name="scheme_label_sms">محرر الرسائل القصيرة</string>
+	<string name="scheme_label_mms">محرر MMS</string>
+	<string name="scheme_label_mailto">محرر البريد الإلكتروني</string>
+	<string name="scheme_label_other">تطبيق خارجي (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -415,4 +415,13 @@
 	<string name="parsed_type_calendar_event">Събитие в календара</string>
 	<string name="parsed_type_wifi_network">Wi-Fi мрежа</string>
 	<string name="formatted_json">Форматиран JSON</string>
+
+	<string name="scheme_dialog_title">Разрешаване на действието?</string>
+	<string name="scheme_dialog_body">Този QR код иска да отвори %1$s с:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Отвори</string>
+	<string name="scheme_label_tel">телефонен набиращ</string>
+	<string name="scheme_label_sms">редактор на SMS</string>
+	<string name="scheme_label_mms">редактор на MMS</string>
+	<string name="scheme_label_mailto">редактор на имейл</string>
+	<string name="scheme_label_other">външно приложение (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -415,4 +415,13 @@
 	<string name="parsed_type_calendar_event">ক্যালেন্ডার ইভেন্ট</string>
 	<string name="parsed_type_wifi_network">Wi-Fi নেটওয়ার্ক</string>
 	<string name="formatted_json">ফরম্যাট করা JSON</string>
+
+	<string name="scheme_dialog_title">এই ক্রিয়াটির অনুমতি দিন?</string>
+	<string name="scheme_dialog_body">এই QR কোড %1$s খুলতে চায়:\n\n%2$s</string>
+	<string name="scheme_dialog_open">খুলুন</string>
+	<string name="scheme_label_tel">ফোন ডায়ালার</string>
+	<string name="scheme_label_sms">SMS রচয়িতা</string>
+	<string name="scheme_label_mms">MMS রচয়িতা</string>
+	<string name="scheme_label_mailto">ইমেল রচয়িতা</string>
+	<string name="scheme_label_other">বাহ্যিক অ্যাপ (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -423,4 +423,13 @@
 	<string name="parsed_type_calendar_event">Událost kalendáře</string>
 	<string name="parsed_type_wifi_network">Síť Wi-Fi</string>
 	<string name="formatted_json">Formátovaný JSON</string>
+
+	<string name="scheme_dialog_title">Povolit tuto akci?</string>
+	<string name="scheme_dialog_body">Tento QR kód chce otevřít %1$s s:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Otevřít</string>
+	<string name="scheme_label_tel">telefonní vytáčení</string>
+	<string name="scheme_label_sms">editor SMS</string>
+	<string name="scheme_label_mms">editor MMS</string>
+	<string name="scheme_label_mailto">editor e-mailu</string>
+	<string name="scheme_label_other">externí aplikace (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -415,4 +415,13 @@
 	<string name="parsed_type_calendar_event">Kalenderbegivenhed</string>
 	<string name="parsed_type_wifi_network">Wi-Fi-netværk</string>
 	<string name="formatted_json">Formatteret JSON</string>
+
+	<string name="scheme_dialog_title">Tillad denne handling?</string>
+	<string name="scheme_dialog_body">Denne QR-kode vil åbne %1$s med:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Åbn</string>
+	<string name="scheme_label_tel">telefonopkald</string>
+	<string name="scheme_label_sms">SMS-editor</string>
+	<string name="scheme_label_mms">MMS-editor</string>
+	<string name="scheme_label_mailto">e-mail-editor</string>
+	<string name="scheme_label_other">ekstern app (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -415,4 +415,13 @@
 	<string name="parsed_type_calendar_event">Kalenderereignis</string>
 	<string name="parsed_type_wifi_network">WLAN-Netzwerk</string>
 	<string name="formatted_json">Formatiertes JSON</string>
+
+	<string name="scheme_dialog_title">Diese Aktion erlauben?</string>
+	<string name="scheme_dialog_body">Dieser QR-Code möchte %1$s öffnen mit:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Öffnen</string>
+	<string name="scheme_label_tel">Telefon-App</string>
+	<string name="scheme_label_sms">SMS-Editor</string>
+	<string name="scheme_label_mms">MMS-Editor</string>
+	<string name="scheme_label_mailto">E-Mail-Editor</string>
+	<string name="scheme_label_other">externe App (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -416,4 +416,13 @@
 	<string name="parsed_type_calendar_event">Evento del calendario</string>
 	<string name="parsed_type_wifi_network">Red Wi-Fi</string>
 	<string name="formatted_json">JSON formateado</string>
+
+	<string name="scheme_dialog_title">¿Permitir esta acción?</string>
+	<string name="scheme_dialog_body">Este código QR quiere abrir %1$s con:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Abrir</string>
+	<string name="scheme_label_tel">marcador de teléfono</string>
+	<string name="scheme_label_sms">editor de SMS</string>
+	<string name="scheme_label_mms">editor de MMS</string>
+	<string name="scheme_label_mailto">editor de correo</string>
+	<string name="scheme_label_other">aplicación externa (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -415,4 +415,13 @@
 	<string name="parsed_type_calendar_event">رویداد تقویم</string>
 	<string name="parsed_type_wifi_network">شبکه Wi-Fi</string>
 	<string name="formatted_json">JSON قالب‌بندی‌شده</string>
+
+	<string name="scheme_dialog_title">این عمل مجاز است؟</string>
+	<string name="scheme_dialog_body">این کد QR می‌خواهد %1$s را با این باز کند:\n\n%2$s</string>
+	<string name="scheme_dialog_open">باز کردن</string>
+	<string name="scheme_label_tel">شماره‌گیر تلفن</string>
+	<string name="scheme_label_sms">ویرایشگر پیامک</string>
+	<string name="scheme_label_mms">ویرایشگر MMS</string>
+	<string name="scheme_label_mailto">ویرایشگر ایمیل</string>
+	<string name="scheme_label_other">برنامه خارجی (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -416,4 +416,13 @@
 	<string name="parsed_type_calendar_event">Événement du calendrier</string>
 	<string name="parsed_type_wifi_network">Réseau Wi-Fi</string>
 	<string name="formatted_json">JSON formaté</string>
+
+	<string name="scheme_dialog_title">Autoriser cette action ?</string>
+	<string name="scheme_dialog_body">Ce code QR souhaite ouvrir %1$s avec :\n\n%2$s</string>
+	<string name="scheme_dialog_open">Ouvrir</string>
+	<string name="scheme_label_tel">composeur téléphonique</string>
+	<string name="scheme_label_sms">rédacteur SMS</string>
+	<string name="scheme_label_mms">rédacteur MMS</string>
+	<string name="scheme_label_mailto">rédacteur d\'e-mail</string>
+	<string name="scheme_label_other">application externe (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -415,4 +415,13 @@
 	<string name="parsed_type_calendar_event">Naptári esemény</string>
 	<string name="parsed_type_wifi_network">Wi-Fi hálózat</string>
 	<string name="formatted_json">Formázott JSON</string>
+
+	<string name="scheme_dialog_title">Engedélyezi ezt a műveletet?</string>
+	<string name="scheme_dialog_body">Ez a QR-kód meg szeretné nyitni a(z) %1$s alkalmazást:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Megnyitás</string>
+	<string name="scheme_label_tel">telefon tárcsázó</string>
+	<string name="scheme_label_sms">SMS szerkesztő</string>
+	<string name="scheme_label_mms">MMS szerkesztő</string>
+	<string name="scheme_label_mailto">e-mail szerkesztő</string>
+	<string name="scheme_label_other">külső alkalmazás (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -413,4 +413,13 @@
 	<string name="parsed_type_calendar_event">Acara kalender</string>
 	<string name="parsed_type_wifi_network">Jaringan Wi-Fi</string>
 	<string name="formatted_json">JSON terformat</string>
+
+	<string name="scheme_dialog_title">Izinkan tindakan ini?</string>
+	<string name="scheme_dialog_body">Kode QR ini ingin membuka %1$s dengan:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Buka</string>
+	<string name="scheme_label_tel">panggilan telepon</string>
+	<string name="scheme_label_sms">penulis SMS</string>
+	<string name="scheme_label_mms">penulis MMS</string>
+	<string name="scheme_label_mailto">penulis email</string>
+	<string name="scheme_label_other">aplikasi eksternal (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -417,4 +417,13 @@
 	<string name="parsed_type_calendar_event">Evento calendario</string>
 	<string name="parsed_type_wifi_network">Rete Wi-Fi</string>
 	<string name="formatted_json">JSON formattato</string>
+
+	<string name="scheme_dialog_title">Consentire questa azione?</string>
+	<string name="scheme_dialog_body">Questo codice QR vuole aprire %1$s con:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Apri</string>
+	<string name="scheme_label_tel">dialer del telefono</string>
+	<string name="scheme_label_sms">editor SMS</string>
+	<string name="scheme_label_mms">editor MMS</string>
+	<string name="scheme_label_mailto">editor email</string>
+	<string name="scheme_label_other">app esterna (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -413,4 +413,13 @@
 	<string name="parsed_type_calendar_event">カレンダーイベント</string>
 	<string name="parsed_type_wifi_network">Wi-Fi ネットワーク</string>
 	<string name="formatted_json">整形済み JSON</string>
+
+	<string name="scheme_dialog_title">この操作を許可しますか？</string>
+	<string name="scheme_dialog_body">このQRコードは%1$sを開こうとしています:\n\n%2$s</string>
+	<string name="scheme_dialog_open">開く</string>
+	<string name="scheme_label_tel">電話アプリ</string>
+	<string name="scheme_label_sms">SMS作成画面</string>
+	<string name="scheme_label_mms">MMS作成画面</string>
+	<string name="scheme_label_mailto">メール作成画面</string>
+	<string name="scheme_label_other">外部アプリ (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -415,4 +415,13 @@
 	<string name="parsed_type_calendar_event">კალენდრის მოვლენა</string>
 	<string name="parsed_type_wifi_network">Wi-Fi ქსელი</string>
 	<string name="formatted_json">დაფორმატებული JSON</string>
+
+	<string name="scheme_dialog_title">ნება დართოთ ამ მოქმედებას?</string>
+	<string name="scheme_dialog_body">ეს QR კოდი ცდილობს გახსნას %1$s ამით:\n\n%2$s</string>
+	<string name="scheme_dialog_open">გახსნა</string>
+	<string name="scheme_label_tel">ტელეფონის გამოძახება</string>
+	<string name="scheme_label_sms">SMS რედაქტორი</string>
+	<string name="scheme_label_mms">MMS რედაქტორი</string>
+	<string name="scheme_label_mailto">ელფოსტის რედაქტორი</string>
+	<string name="scheme_label_other">გარე აპლიკაცია (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -413,4 +413,13 @@
 	<string name="parsed_type_calendar_event">캘린더 이벤트</string>
 	<string name="parsed_type_wifi_network">Wi-Fi 네트워크</string>
 	<string name="formatted_json">서식이 지정된 JSON</string>
+
+	<string name="scheme_dialog_title">이 작업을 허용하시겠습니까?</string>
+	<string name="scheme_dialog_body">이 QR 코드가 %1$s을(를) 열려고 합니다:\n\n%2$s</string>
+	<string name="scheme_dialog_open">열기</string>
+	<string name="scheme_label_tel">전화 다이얼러</string>
+	<string name="scheme_label_sms">SMS 작성기</string>
+	<string name="scheme_label_mms">MMS 작성기</string>
+	<string name="scheme_label_mailto">이메일 작성기</string>
+	<string name="scheme_label_other">외부 앱 (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -419,4 +419,13 @@
 	<string name="vds_issuing_country">Izdevējvalsts</string>
 	<string name="vds_signing_date">Parakstīšanas datums</string>
 	<string name="formatted_json">Formatēts JSON</string>
+
+	<string name="scheme_dialog_title">Atļaut šo darbību?</string>
+	<string name="scheme_dialog_body">Šis QR kods vēlas atvērt %1$s ar:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Atvērt</string>
+	<string name="scheme_label_tel">tālruņa zvanītājs</string>
+	<string name="scheme_label_sms">SMS redaktors</string>
+	<string name="scheme_label_mms">MMS redaktors</string>
+	<string name="scheme_label_mailto">e-pasta redaktors</string>
+	<string name="scheme_label_other">ārēja lietotne (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -415,4 +415,13 @@
 	<string name="parsed_type_calendar_event">Agenda-afspraak</string>
 	<string name="parsed_type_wifi_network">Wi-Fi-netwerk</string>
 	<string name="formatted_json">Opgemaakte JSON</string>
+
+	<string name="scheme_dialog_title">Deze actie toestaan?</string>
+	<string name="scheme_dialog_body">Deze QR-code wil %1$s openen met:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Openen</string>
+	<string name="scheme_label_tel">telefoonkiezer</string>
+	<string name="scheme_label_sms">SMS-bewerker</string>
+	<string name="scheme_label_mms">MMS-bewerker</string>
+	<string name="scheme_label_mailto">e-mailbewerker</string>
+	<string name="scheme_label_other">externe app (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -423,4 +423,13 @@
 	<string name="parsed_type_calendar_event">Wydarzenie kalendarza</string>
 	<string name="parsed_type_wifi_network">Sieć Wi-Fi</string>
 	<string name="formatted_json">Sformatowany JSON</string>
+
+	<string name="scheme_dialog_title">Zezwolić na tę akcję?</string>
+	<string name="scheme_dialog_body">Ten kod QR chce otworzyć %1$s z:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Otwórz</string>
+	<string name="scheme_label_tel">telefoniczny wybierak</string>
+	<string name="scheme_label_sms">edytor SMS</string>
+	<string name="scheme_label_mms">edytor MMS</string>
+	<string name="scheme_label_mailto">edytor e-mail</string>
+	<string name="scheme_label_other">zewnętrzna aplikacja (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -415,4 +415,13 @@
 	<string name="parsed_type_calendar_event">Evento do calendário</string>
 	<string name="parsed_type_wifi_network">Rede Wi-Fi</string>
 	<string name="formatted_json">JSON formatado</string>
+
+	<string name="scheme_dialog_title">Permitir esta ação?</string>
+	<string name="scheme_dialog_body">Este código QR quer abrir o %1$s com:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Abrir</string>
+	<string name="scheme_label_tel">discador de telefone</string>
+	<string name="scheme_label_sms">compositor de SMS</string>
+	<string name="scheme_label_mms">compositor de MMS</string>
+	<string name="scheme_label_mailto">compositor de e-mail</string>
+	<string name="scheme_label_other">aplicativo externo (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -423,4 +423,13 @@
 	<string name="parsed_type_calendar_event">Событие календаря</string>
 	<string name="parsed_type_wifi_network">Сеть Wi-Fi</string>
 	<string name="formatted_json">Отформатированный JSON</string>
+
+	<string name="scheme_dialog_title">Разрешить это действие?</string>
+	<string name="scheme_dialog_body">Этот QR-код хочет открыть %1$s с:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Открыть</string>
+	<string name="scheme_label_tel">приложение телефон</string>
+	<string name="scheme_label_sms">редактор SMS</string>
+	<string name="scheme_label_mms">редактор MMS</string>
+	<string name="scheme_label_mailto">редактор электронной почты</string>
+	<string name="scheme_label_other">внешнее приложение (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -415,4 +415,13 @@
 	<string name="parsed_type_calendar_event">Takvim etkinliği</string>
 	<string name="parsed_type_wifi_network">Wi-Fi ağı</string>
 	<string name="formatted_json">Biçimlendirilmiş JSON</string>
+
+	<string name="scheme_dialog_title">Bu eyleme izin ver?</string>
+	<string name="scheme_dialog_body">Bu QR kodu %1$s ile açmak istiyor:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Aç</string>
+	<string name="scheme_label_tel">telefon arayıcı</string>
+	<string name="scheme_label_sms">SMS düzenleyici</string>
+	<string name="scheme_label_mms">MMS düzenleyici</string>
+	<string name="scheme_label_mailto">e-posta düzenleyici</string>
+	<string name="scheme_label_other">harici uygulama (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -423,4 +423,13 @@
 	<string name="parsed_type_calendar_event">Подія календаря</string>
 	<string name="parsed_type_wifi_network">Мережа Wi-Fi</string>
 	<string name="formatted_json">Відформатований JSON</string>
+
+	<string name="scheme_dialog_title">Дозволити цю дію?</string>
+	<string name="scheme_dialog_body">Цей QR-код хоче відкрити %1$s з:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Відкрити</string>
+	<string name="scheme_label_tel">телефонний набиральник</string>
+	<string name="scheme_label_sms">редактор SMS</string>
+	<string name="scheme_label_mms">редактор MMS</string>
+	<string name="scheme_label_mailto">редактор електронної пошти</string>
+	<string name="scheme_label_other">зовнішня програма (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -413,4 +413,13 @@
 	<string name="parsed_type_calendar_event">Sự kiện lịch</string>
 	<string name="parsed_type_wifi_network">Mạng Wi-Fi</string>
 	<string name="formatted_json">JSON đã định dạng</string>
+
+	<string name="scheme_dialog_title">Cho phép hành động này?</string>
+	<string name="scheme_dialog_body">Mã QR này muốn mở %1$s với:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Mở</string>
+	<string name="scheme_label_tel">trình quay số</string>
+	<string name="scheme_label_sms">trình soạn SMS</string>
+	<string name="scheme_label_mms">trình soạn MMS</string>
+	<string name="scheme_label_mailto">trình soạn email</string>
+	<string name="scheme_label_other">ứng dụng bên ngoài (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -413,4 +413,13 @@
 	<string name="parsed_type_calendar_event">日历事件</string>
 	<string name="parsed_type_wifi_network">Wi-Fi 网络</string>
 	<string name="formatted_json">格式化的 JSON</string>
+
+	<string name="scheme_dialog_title">允许此操作？</string>
+	<string name="scheme_dialog_body">此二维码想要打开%1$s:\n\n%2$s</string>
+	<string name="scheme_dialog_open">打开</string>
+	<string name="scheme_label_tel">电话拨号器</string>
+	<string name="scheme_label_sms">短信编辑器</string>
+	<string name="scheme_label_mms">彩信编辑器</string>
+	<string name="scheme_label_mailto">邮件编辑器</string>
+	<string name="scheme_label_other">外部应用 (%1$s)</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -413,4 +413,13 @@
 	<string name="parsed_type_calendar_event">行事曆事件</string>
 	<string name="parsed_type_wifi_network">Wi-Fi 網路</string>
 	<string name="formatted_json">格式化的 JSON</string>
+
+	<string name="scheme_dialog_title">允許此操作？</string>
+	<string name="scheme_dialog_body">此 QR 條碼想要開啟%1$s:\n\n%2$s</string>
+	<string name="scheme_dialog_open">開啟</string>
+	<string name="scheme_label_tel">電話撥號器</string>
+	<string name="scheme_label_sms">簡訊編輯器</string>
+	<string name="scheme_label_mms">彩信編輯器</string>
+	<string name="scheme_label_mailto">郵件編輯器</string>
+	<string name="scheme_label_other">外部應用程式 (%1$s)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -414,4 +414,12 @@
 	<string name="vds_issuing_country">Issuing Country</string>
 	<string name="vds_signing_date">Signing Date</string>
 	<string name="formatted_json">Formatted JSON</string>
+	<string name="scheme_dialog_title">Allow this action?</string>
+	<string name="scheme_dialog_body">This QR code wants to open the %1$s with:\n\n%2$s</string>
+	<string name="scheme_dialog_open">Open</string>
+	<string name="scheme_label_tel">phone dialer</string>
+	<string name="scheme_label_sms">SMS composer</string>
+	<string name="scheme_label_mms">MMS composer</string>
+	<string name="scheme_label_mailto">email composer</string>
+	<string name="scheme_label_other">external app (%1$s)</string>
 </resources>


### PR DESCRIPTION
## Problem

Right now any URI a QR code resolves to is handed straight to `Intent.ACTION_VIEW` the moment the user taps the open icon in the action sheet. For `http`/`https`/`content`/`file` that's the expected behaviour, but for `tel:` / `sms:` / `mailto:` / `intent:` / arbitrary custom schemes it means a malicious QR can:

- Auto-dial a premium-rate number via `tel:`
- Pre-compose an SMS to a short-code via `sms:` / `smsto:`
- Hand off to an arbitrary app via `intent://com.target.app/...#Intent;...;end`
- Trigger a custom-scheme deep link the user didn't realise was a privileged action

…before the user has any chance to read the actual destination. The action sheet shows the parsed content, but the act of tapping the open icon commits the launch.

## Fix

A single `AlertDialog` before `openUri()` launches the intent — but **only** for schemes other than `http`, `https`, `content`, `file`. http(s) URLs continue to open immediately as before — zero added friction for the common case.

The dialog shows:
- The full URI
- A human-readable description of which app it would open: `"phone dialer"`, `"SMS composer"`, `"MMS composer"`, `"email composer"`, or `"external app (\<scheme\>)"` for anything else

Default action is Cancel; positive button is "Open".

## What changes

- `app/src/main/kotlin/de/markusfisch/android/binaryeye/content/Share.kt` (+41): `openUri()` now branches by scheme; non-standard schemes route through a new `AlertDialog`. Standard schemes (and `silent=true` calls) go to a small extracted `launchUri()` helper that preserves the original behaviour (`FLAG_GRANT_READ_URI_PERMISSION` for `content://`, `execShareIntent` vs `startIntent` based on `silent`).
- `app/src/main/res/values/strings.xml` (+8): five scheme-label strings, dialog title, body template, "Open" button label.

No new permissions, no new dependencies, no UI changes outside the new dialog.

## Tested

- Scanned a QR encoding `tel:+12025551234` → dialog shows "phone dialer" + URI → Cancel does nothing, Open launches the dialer ✓
- Scanned an `https://example.com/...` URL → opens immediately, no dialog (same as today) ✓
- Scanned a `mailto:test@example.com?subject=...` → dialog shows "email composer" ✓
- Scanned an `intent://...#Intent;...;end` → dialog shows "external app (intent)" ✓
- Sharing flow (`silent=true` path) → bypasses dialog as expected ✓

## Notes

- The `silent` parameter on `openUri()` is preserved untouched — bypasses the confirmation since silent callers are internal openers (the user has already approved through another flow).
- The dialog only fires when the calling Context is an Activity (which it always is in practice from the action sheet). If somehow called from a non-Activity Context, the call falls back to the original behaviour.
- If you'd prefer this to be opt-in behind a setting (e.g., for users who scan a lot of `tel:` codes legitimately), happy to add a toggle.