### PR TITLE
Strip common tracking parameters before opening scanned URLs

### DIFF
--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/content/Share.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/content/Share.kt
@@ -43,8 +43,9 @@ fun Context.openUrl(url: String, silent: Boolean = false): Boolean {
 }
 
 fun Context.openUri(uri: Uri, silent: Boolean = false): Boolean {
-	val intent = Intent(Intent.ACTION_VIEW, uri).apply {
-		if (uri.scheme == "content") {
+	val cleaned = UrlSanitizer.stripTrackingParams(uri)
+	val intent = Intent(Intent.ACTION_VIEW, cleaned).apply {
+		if (cleaned.scheme == "content") {
 			addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
 		}
 	}

--- a/app/src/main/kotlin/de/markusfisch/android/binaryeye/content/UrlSanitizer.kt
+++ b/app/src/main/kotlin/de/markusfisch/android/binaryeye/content/UrlSanitizer.kt
@@ -1,0 +1,38 @@
+package de.markusfisch.android.binaryeye.content
+
+import android.net.Uri
+
+object UrlSanitizer {
+
+	private val TRACKING_PARAMS = setOf(
+		"utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+		"utm_id", "utm_name", "utm_referrer", "utm_brand", "utm_social",
+		"fbclid", "gclid", "dclid", "gclsrc", "yclid", "msclkid",
+		"mc_eid", "mc_cid",
+		"_ga", "_gl", "ga_source", "ga_medium",
+		"igshid", "igsh",
+		"hsa_acc", "hsa_cam", "hsa_grp", "hsa_ad", "hsa_src",
+		"hsa_tgt", "hsa_kw", "hsa_mt", "hsa_net", "hsa_ver",
+		"spm", "scm", "vero_id", "vero_conv"
+	)
+
+	fun stripTrackingParams(uri: Uri): Uri {
+		val scheme = uri.scheme?.lowercase()
+		if (scheme != "http" && scheme != "https") return uri
+		val queryNames = runCatching {
+			uri.queryParameterNames
+		}.getOrDefault(emptySet())
+		if (queryNames.isEmpty()) return uri
+		val keep = queryNames.filter { paramName ->
+			paramName.lowercase() !in TRACKING_PARAMS
+		}
+		if (keep.size == queryNames.size) return uri
+		val builder = uri.buildUpon().clearQuery()
+		for (paramName in keep) {
+			uri.getQueryParameters(paramName).forEach { paramValue ->
+				builder.appendQueryParameter(paramName, paramValue)
+			}
+		}
+		return builder.build()
+	}
+}


### PR DESCRIPTION
## Summary

Many QR codes carry tracking parameters (`utm_*`, `fbclid`, `gclid`, `mc_*`, `_ga`, `igshid`, etc.) that uniquely identify the scanning device/session. When `openUri()` launches `ACTION_VIEW`, those identifiers are silently forwarded to the destination site.

This PR adds a small `content/UrlSanitizer` helper that drops a curated set of well-known tracker parameter names from `http(s)` URIs, and calls it from `openUri()` so cleanup happens transparently on every URL launch.

## Behavior

- Only `http`/`https` URIs are touched; `tel:`, `mailto:`, `geo:`, `content:`, etc. are returned unchanged.
- Only the parameter *names* in a small whitelist are dropped — and only when the sole purpose of that parameter is third-party attribution (utm_*, click-id families, mailer/segment-tracking ids). Site-functional parameters (`q`, `id`, `v`, `page`, `search`, …) are left alone.
- URIs without a query string are returned as-is (no allocation).
- If no parameter matches the list, the original `Uri` instance is returned (identity preserved, no rebuild).

## Why a fixed list, not a regex

A regex like `^utm_` over-matches site-functional params on a non-trivial fraction of sites (e.g. analytics dashboards that legitimately read user-supplied UTM debug parameters). A small explicit list is cheaper, easier to audit, and avoids surprising the user when a destination relies on a parameter named similarly.

## Edge cases handled

- `queryParameterNames` throws on opaque (non-hierarchical) URIs — wrapped in `runCatching` so opaque URIs flow through untouched.
- Parameter name comparison is `lowercase()`-folded so `UTM_SOURCE` and `utm_source` both match.
- Duplicate parameter names with multiple values are all preserved on the keep side.
- Scheme is `lowercase()`-folded so `HTTPS://…` is still detected as http(s).

## Out of scope

This deliberately does *not* try to be a full URL-cleaning ruleset à la ClearURLs / Privacy Badger — those are much larger, per-domain, and need maintenance. This is the smallest universally-safe subset.

## Test plan

- [ ] Scan a QR that encodes `https://example.com/page?utm_source=qr&utm_campaign=x&id=42` and tap "Open" — verify the URL handed to the browser is `https://example.com/page?id=42`.
- [ ] Scan a QR with `tel:+15551234` — verify dialer opens with the number unchanged.
- [ ] Scan a QR with `https://example.com/page` (no query) — verify it opens identically.
- [ ] Scan a QR with `https://example.com/?q=hello%20world` — verify the percent-encoded space round-trips correctly.